### PR TITLE
Added react-passthrough component to pass through "extra" props

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ build/Release
 node_modules
 
 lib/
+/jsconfig.json

--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
   "dependencies": {
     "babel-runtime": "^5.8.29",
     "deep-equal": "^1.0.1",
-    "radium": "^0.16.6",
+    "radium": "^0.17.1",
+    "react-passthrough": "^0.1.0",
     "react-utils": "alexcurtis/react-utils",
     "shallowequal": "^0.2.2",
     "velocity-react": "^1.1.2"

--- a/src/components/decorators.js
+++ b/src/components/decorators.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import Radium from 'radium';
 import {VelocityComponent} from 'velocity-react';
+import passThrough from 'react-passthrough';
 
 const Loading = (props) => {
     return (
@@ -70,6 +71,7 @@ class Container extends React.Component {
                 style={style.container}>
                 { !terminal ? this.renderToggle() : null }
                 <decorators.Header
+                    {...this.passthrough()}
                     node={node}
                     style={style.header}
                 />
@@ -89,7 +91,7 @@ class Container extends React.Component {
     }
     renderToggleDecorator(){
         const {style, decorators} = this.props;
-        return (<decorators.Toggle style={style.toggle}/>);
+        return (<decorators.Toggle {...this.passthrough()} style={style.toggle}/>);
     }
 }
 
@@ -104,6 +106,8 @@ Container.propTypes = {
     ]).isRequired,
     node: React.PropTypes.object.isRequired
 };
+
+passThrough({omit: ['children', 'form']})(Container);
 
 export default {
     Loading,

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import shallowEqual from 'shallowequal';
 import deepEqual from 'deep-equal';
+import passThrough from 'react-passthrough';
 
 class NodeHeader extends React.Component {
     constructor(props){
@@ -27,6 +28,7 @@ class NodeHeader extends React.Component {
         const headerStyles = Object.assign({ container }, this.props.style);
         return (
             <decorators.Container
+                {...this.passthrough()}
                 style={headerStyles}
                 decorators={decorators}
                 terminal={terminal}
@@ -48,5 +50,7 @@ NodeHeader.propTypes = {
     node: React.PropTypes.object.isRequired,
     onClick: React.PropTypes.func
 };
+
+passThrough({omit: ['children', 'form']})(NodeHeader);
 
 export default NodeHeader;

--- a/src/components/node.js
+++ b/src/components/node.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import rutils from 'react-utils';
 import {VelocityTransitionGroup} from 'velocity-react';
+import passThrough from 'react-passthrough';
 
 import NodeHeader from './header';
 
@@ -56,6 +57,7 @@ class TreeNode extends React.Component {
     renderHeader(decorators, animations){
         return (
             <NodeHeader
+                {...this.passthrough()}
                 decorators={decorators}
                 animations={animations}
                 style={this.props.style}
@@ -70,6 +72,7 @@ class TreeNode extends React.Component {
             <ul style={this.props.style.subtree} ref="subtree">
                 {rutils.children.map(this.props.node.children, (child, index) =>
                     <TreeNode
+                        {...this.passthrough()}
                         {...this._eventBubbles()}
                         key={child.id || index}
                         node={child}
@@ -85,7 +88,7 @@ class TreeNode extends React.Component {
         return (
             <ul style={this.props.style.subtree}>
                 <li>
-                    <decorators.Loading style={this.props.style.loading}/>
+                    <decorators.Loading {...this.passthrough()} style={this.props.style.loading}/>
                 </li>
             </ul>
         );
@@ -105,5 +108,7 @@ TreeNode.propTypes = {
     ]).isRequired,
     onToggle: React.PropTypes.func
 };
+
+passThrough({omit: ['children', 'form']})(TreeNode);
 
 export default TreeNode;

--- a/src/components/treebeard.js
+++ b/src/components/treebeard.js
@@ -6,6 +6,7 @@ import TreeNode from './node';
 import defaultDecorators from './decorators';
 import defaultTheme from '../themes/default';
 import defaultAnimations from '../themes/animations';
+import passThrough from 'react-passthrough';
 
 class TreeBeard extends React.Component {
     constructor(props){
@@ -15,10 +16,12 @@ class TreeBeard extends React.Component {
         let data = this.props.data;
         // Support Multiple Root Nodes. Its not formally a tree, but its a use-case.
         if(!Array.isArray(data)){ data = [data]; }
+        const self = this;
         return (
             <ul style={this.props.style.tree.base} ref="treeBase">
                 {data.map((node, index) =>
                     <TreeNode
+                        {...self.passthrough()}
                         key={node.id || index}
                         node={node}
                         onToggle={this.props.onToggle}
@@ -51,5 +54,7 @@ TreeBeard.defaultProps = {
     animations: defaultAnimations,
     decorators: defaultDecorators
 };
+
+passThrough({omit: ['children', 'form', 'data']})(TreeBeard);
 
 export default TreeBeard;


### PR DESCRIPTION
Allows for passing custom props into custom decorators. An attempt to accomplish #16 in a generic fashion.
